### PR TITLE
modify property name logLevel  to camelCase

### DIFF
--- a/pact/pact-react-consumer/pact/setup-graphql.js
+++ b/pact/pact-react-consumer/pact/setup-graphql.js
@@ -6,7 +6,7 @@ global.provider = new Pact({
     cors: true,
     port: global.port,
     log: path.resolve(process.cwd(), 'logs', 'pact.log'),
-    loglevel: 'debug',
+    logLevel: 'debug',
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'update',

--- a/pact/pact-react-consumer/pact/setup.js
+++ b/pact/pact-react-consumer/pact/setup.js
@@ -6,7 +6,7 @@ global.provider = new Pact({
     cors: true,
     port: global.port,
     log: path.resolve(process.cwd(), 'logs', 'pact.log'),
-    loglevel: 'debug',
+    logLevel: 'debug',
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'update',


### PR DESCRIPTION
Test file in the pact-react-consumer directory, property name of `logLevel` is not camelCase.

Check the version 7.0.3 of the pact which is used by this project, the `logLevel` property is defined in camel, so I modified it according to this.

https://github.com/pact-foundation/pact-js/blob/v7.0.3/src/dsl/options.ts#L40