### PR TITLE
rename package 'de.kuksin' to 'io.refectoring'

### DIFF
--- a/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/TestcontainersApplication.java
+++ b/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/TestcontainersApplication.java
@@ -1,4 +1,4 @@
-package de.kuksin.testcontainers;
+package io.reflectoring.testcontainers;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/entities/Car.java
+++ b/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/entities/Car.java
@@ -1,4 +1,4 @@
-package de.kuksin.testcontainers.entities;
+package io.reflectoring.testcontainers.entities;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/repositories/CarRepository.java
+++ b/spring-boot/testcontainers/src/main/java/io/reflectoring/testcontainers/repositories/CarRepository.java
@@ -1,6 +1,6 @@
-package de.kuksin.testcontainers.repositories;
+package io.reflectoring.testcontainers.repositories;
 
-import de.kuksin.testcontainers.entities.Car;
+import io.reflectoring.testcontainers.entities.Car;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;

--- a/spring-boot/testcontainers/src/test/java/io/reflectoring/testcontainers/AbstractIntegrationTest.java
+++ b/spring-boot/testcontainers/src/test/java/io/reflectoring/testcontainers/AbstractIntegrationTest.java
@@ -1,4 +1,4 @@
-package de.kuksin.testcontainers;
+package io.reflectoring.testcontainers;
 
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;

--- a/spring-boot/testcontainers/src/test/java/io/reflectoring/testcontainers/TestcontainersApplicationTests.java
+++ b/spring-boot/testcontainers/src/test/java/io/reflectoring/testcontainers/TestcontainersApplicationTests.java
@@ -1,4 +1,4 @@
-package de.kuksin.testcontainers;
+package io.reflectoring.testcontainers;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Just renaming the packages in the testcontainers example.