### PR TITLE
fix/article-title

### DIFF
--- a/aws/spring-cloud-aws-s3/README.md
+++ b/aws/spring-cloud-aws-s3/README.md
@@ -22,5 +22,5 @@ sudo docker-compose up -d
 
 Blog posts about this topic:
 
-* [Using Amazon S3 with Spring Cloud AWS](https://reflectoring.io/spring-cloud-aws-s3/)
-* [Using AWS S3 Presigned URLs in Spring Boot](https://reflectoring.io/aws-s3-presigned-url-spring-boot/)
+* [Integrating Amazon S3 with Spring Boot Using Spring Cloud AWS](https://reflectoring.io/integrating-amazon-s3-with-spring-boot-using-spring-cloud-aws/)
+* [Offloading File Transfers with Amazon S3 Presigned URLs in Spring Boot](https://reflectoring.io/offloading-file-transfers-with-amazon-s3-presigned-urls-in-spring-boot/)


### PR DESCRIPTION
Updating the README.md file of the `spring-cloud-aws-s3` project to reflect the updated article title names of: 

* Integrating Amazon S3 with Spring Boot Using Spring Cloud AWS
* Offloading File Transfers with Amazon S3 Presigned URLs in Spring Boot

Article titles and URL changed in this PR: https://github.com/reflectoring/reflectoring.github.io/pull/564.
